### PR TITLE
fix: increase default retry count and expand error matching criteria

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -146,10 +146,14 @@ export async function retry<T>(
 }
 
 const retryDefaults: RetryOptions = {
-  retries: 5,
+  retries: 20,
   intervalMs: 200,
   timeoutMs: 5000,
-  errorMatch: ['context or browser has been closed', 'Promise was collected'],
+  errorMatch: [
+    'context or browser has been closed',
+    'Promise was collected',
+    'Execution context was destroyed',
+  ],
 }
 
 const currentRetryOptions: RetryOptions = { ...retryDefaults }


### PR DESCRIPTION
This pull request includes a change to the `retry` function in the `src/utilities.ts` file to improve its robustness by increasing the number of retries and expanding the list of error messages that trigger a retry.

Improvements to retry logic:

* [`src/utilities.ts`](diffhunk://#diff-ff9fce47ffc7d1950d0a67376141c6b4fca4f6f1f85b6ada38380656a35fbfe9L149-R156): Increased the default number of retries from 5 to 20 to enhance the function's resilience.
* [`src/utilities.ts`](diffhunk://#diff-ff9fce47ffc7d1950d0a67376141c6b4fca4f6f1f85b6ada38380656a35fbfe9L149-R156): Added 'Execution context was destroyed' to the list of error messages that trigger a retry to handle additional failure scenarios.