### PR TITLE
fix: disable retry + remove browserWindowWithRetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,6 @@ throwing an error saying the execution context has been destroyed.
 This function retries the evaluation several times to see if it can
 run the evaluation without an error. If it fails after the retries,
 it throws the error.</p></dd>
-<dt><a href="#browserWindowWithRetry">browserWindowWithRetry(app, page, options)</a> ⇒</dt>
-<dd><p>Returns the BrowserWindow object that corresponds to the given Playwright page (with retries).</p>
-<p>This is basically a wrapper around <code>[app.browserWindow(page)](https://playwright.dev/docs/api/class-electronapplication#electron-application-browser-window)</code>
-that retries the operation.</p></dd>
 <dt><a href="#retryUntilTruthy">retryUntilTruthy(fn, [timeoutMs], [intervalMs])</a> ⇒ <code>Promise.&lt;T&gt;</code></dt>
 <dd><p>Retries a given function until it returns a truthy value or the timeout is reached.</p>
 <p>This offers similar functionality to Playwright's <a href="https://playwright.dev/docs/api/class-page#page-wait-for-function"><code>page.waitForFunction()</code></a>
@@ -339,28 +335,6 @@ it throws the error.</p>
 | arg | <code>Any</code> | <p>an argument to pass to the function</p> |
 | retries |  | <p>the number of times to retry the evaluation</p> |
 | retryIntervalMs |  | <p>the interval between retries</p> |
-
-<a name="browserWindowWithRetry"></a>
-
-## browserWindowWithRetry(app, page, options) ⇒
-<p>Returns the BrowserWindow object that corresponds to the given Playwright page (with retries).</p>
-<p>This is basically a wrapper around <code>[app.browserWindow(page)](https://playwright.dev/docs/api/class-electronapplication#electron-application-browser-window)</code>
-that retries the operation.</p>
-
-**Kind**: global function  
-**Returns**: <p>A promise that resolves to the browser window.</p>  
-**Throws**:
-
-- <p>Will throw an error if all retry attempts fail.</p>
-
-
-| Param | Description |
-| --- | --- |
-| app | <p>The Electron application instance.</p> |
-| page | <p>The Playwright page instance.</p> |
-| options | <p>Optional configuration for retries.</p> |
-| options.retries | <p>The number of retry attempts. Defaults to 5.</p> |
-| options.intervalMs | <p>The interval between retries in milliseconds. Defaults to 200.</p> |
 
 <a name="retryUntilTruthy"></a>
 
@@ -820,8 +794,8 @@ This function retries a given function until it returns without throwing one of 
 | --- | --- | --- | --- |
 | fn | <code>function</code> |  | <p>The function to retry.</p> |
 | [options] | <code>RetryOptions</code> | <code>{}</code> | <p>The options for retrying the function.</p> |
-| [options.intervalMs] | <code>number</code> | <code>200</code> | <p>The delay between each retry attempt in milliseconds.</p> |
-| [options.timeoutMs] | <code>number</code> | <code>5000</code> | <p>The maximum time to wait before giving up in milliseconds.</p> |
+| [options.timeout] | <code>number</code> | <code>5000</code> | <p>The maximum time to wait before giving up in milliseconds.</p> |
+| [options.poll] | <code>number</code> | <code>200</code> | <p>The delay between each retry attempt in milliseconds.</p> |
 | [options.errorMatch] | <code>string</code> \| <code>Array.&lt;string&gt;</code> \| <code>RegExp</code> | <code>&quot;[&#x27;context or browser has been closed&#x27;, &#x27;Promise was collected&#x27;, &#x27;Execution context was destroyed&#x27;]&quot;</code> | <p>String(s) or regex to match against error message. If the error does not match, it will throw immediately. If it does match, it will retry.</p> |
 
 **Example**  

--- a/src/general_helpers.ts
+++ b/src/general_helpers.ts
@@ -19,7 +19,7 @@ export async function electronWaitForFunction<R, Arg>(
   electronApp: ElectronApplication,
   fn: PageFunctionOn<typeof Electron.CrossProcessExports, Arg, R>,
   arg?: Arg,
-  options: RetryOptions = {}
+  options: Partial<RetryOptions> = {}
 ): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -47,7 +47,7 @@ export async function evaluateWithRetry<R, Arg>(
   electronApp: ElectronApplication,
   fn: PageFunctionOn<typeof Electron.CrossProcessExports, Arg, R>,
   arg = {} as Arg,
-  options: RetryOptions = {}
+  options: Partial<RetryOptions> = {}
 ): Promise<R> {
   return retry(() => electronApp.evaluate(fn, arg), options)
 }
@@ -69,7 +69,7 @@ export async function evaluateWithRetry<R, Arg>(
 export async function browserWindowWithRetry(
   app: ElectronApplication,
   page: Page,
-  options: RetryOptions = {}
+  options: Partial<RetryOptions> = {}
 ): Promise<JSHandle> {
   return retry(() => app.browserWindow(page), options)
 }

--- a/src/general_helpers.ts
+++ b/src/general_helpers.ts
@@ -1,4 +1,4 @@
-import type { ElectronApplication, JSHandle, Page } from 'playwright-core'
+import type { ElectronApplication } from 'playwright-core'
 import type { PageFunctionOn } from 'playwright-core/types/structs'
 import { retry, RetryOptions } from './utilities'
 

--- a/src/general_helpers.ts
+++ b/src/general_helpers.ts
@@ -51,25 +51,3 @@ export async function evaluateWithRetry<R, Arg>(
 ): Promise<R> {
   return retry(() => electronApp.evaluate(fn, arg), options)
 }
-
-/**
- * Returns the BrowserWindow object that corresponds to the given Playwright page (with retries).
- *
- * This is basically a wrapper around `[app.browserWindow(page)](https://playwright.dev/docs/api/class-electronapplication#electron-application-browser-window)`
- * that retries the operation.
- *
- * @param app - The Electron application instance.
- * @param page - The Playwright page instance.
- * @param options - Optional configuration for retries.
- * @param options.retries - The number of retry attempts. Defaults to 5.
- * @param options.intervalMs - The interval between retries in milliseconds. Defaults to 200.
- * @returns A promise that resolves to the browser window.
- * @throws Will throw an error if all retry attempts fail.
- */
-export async function browserWindowWithRetry(
-  app: ElectronApplication,
-  page: Page,
-  options: Partial<RetryOptions> = {}
-): Promise<JSHandle> {
-  return retry(() => app.browserWindow(page), options)
-}

--- a/src/menu_helpers.ts
+++ b/src/menu_helpers.ts
@@ -17,7 +17,7 @@ import { RetryOptions, retry } from './utilities'
 export function clickMenuItemById(
   electronApp: ElectronApplication,
   id: string,
-  options: RetryOptions = {}
+  options: Partial<RetryOptions> = {}
 ): Promise<unknown> {
   return retry(
     () =>
@@ -57,7 +57,7 @@ export async function clickMenuItem<P extends keyof MenuItemPartial>(
   electronApp: ElectronApplication,
   property: P,
   value: MenuItemPartial[P],
-  options: RetryOptions = {}
+  options: Partial<RetryOptions> = {}
 ): Promise<unknown> {
   const menuItem = await findMenuItem(electronApp, property, value)
   if (!menuItem) {
@@ -114,7 +114,7 @@ export function getMenuItemAttribute<T extends keyof Electron.MenuItem>(
   electronApp: ElectronApplication,
   menuId: string,
   attribute: T,
-  options: RetryOptions = {}
+  options: Partial<RetryOptions> = {}
 ): Promise<Electron.MenuItem[T]> {
   const attr = attribute as keyof Electron.MenuItem
   const resultPromise = retry(
@@ -175,7 +175,7 @@ export type MenuItemPartial = MenuItemPrimitive & {
 export function getMenuItemById(
   electronApp: ElectronApplication,
   menuId: string,
-  options: RetryOptions = {}
+  options: Partial<RetryOptions> = {}
 ): Promise<MenuItemPartial> {
   return retry(
     () =>
@@ -233,7 +233,7 @@ export function getMenuItemById(
  */
 export function getApplicationMenu(
   electronApp: ElectronApplication,
-  options: RetryOptions = {}
+  options: Partial<RetryOptions> = {}
 ): Promise<MenuItemPartial[] | undefined> {
   const promise = retry(
     () =>

--- a/src/menu_helpers.ts
+++ b/src/menu_helpers.ts
@@ -33,7 +33,7 @@ export function clickMenuItemById(
           throw new Error(`Menu item with id ${menuId} not found`)
         }
       }, id),
-    options
+    { disable: true, ...options }
   )
 }
 
@@ -95,7 +95,7 @@ export async function clickMenuItem<P extends keyof MenuItemPartial>(
         }
         await mI.click()
       }, menuItem.commandId),
-    options
+    { disable: true, ...options }
   )
 }
 


### PR DESCRIPTION
This pull request includes various updates and improvements to the retry functionality across multiple files, as well as the removal of the `browserWindowWithRetry` function. The most important changes include updates to the `RetryOptions` type, adjustments to retry-related functions, and enhancements to the test suite.

### Retry functionality updates:

* [`src/utilities.ts`](diffhunk://#diff-ff9fce47ffc7d1950d0a67376141c6b4fca4f6f1f85b6ada38380656a35fbfe9L82-R92): Updated `RetryOptions` type to include a `disable` option and modified the `retry` and `retryUntilTruthy` functions to use `Partial<RetryOptions>` for better flexibility. [[1]](diffhunk://#diff-ff9fce47ffc7d1950d0a67376141c6b4fca4f6f1f85b6ada38380656a35fbfe9L82-R92) [[2]](diffhunk://#diff-ff9fce47ffc7d1950d0a67376141c6b4fca4f6f1f85b6ada38380656a35fbfe9L125-R145) [[3]](diffhunk://#diff-ff9fce47ffc7d1950d0a67376141c6b4fca4f6f1f85b6ada38380656a35fbfe9L159-R164) [[4]](diffhunk://#diff-ff9fce47ffc7d1950d0a67376141c6b4fca4f6f1f85b6ada38380656a35fbfe9R183) [[5]](diffhunk://#diff-ff9fce47ffc7d1950d0a67376141c6b4fca4f6f1f85b6ada38380656a35fbfe9R246-R247) [[6]](diffhunk://#diff-ff9fce47ffc7d1950d0a67376141c6b4fca4f6f1f85b6ada38380656a35fbfe9R291-R297)
* `src/general_helpers.ts` and `src/menu_helpers.ts`: Changed function parameters to use `Partial<RetryOptions>` instead of `RetryOptions` for improved option handling. [[1]](diffhunk://#diff-0ee7f2fb85f231ef6a5e1c76c07e5802ab0d407703549bd86619754eba179a9dL22-R22) [[2]](diffhunk://#diff-0ee7f2fb85f231ef6a5e1c76c07e5802ab0d407703549bd86619754eba179a9dL50-L75) [[3]](diffhunk://#diff-e402d4d6a386818bd192cd9e2b7cac003fd7b6cbbe49574ca3a6fe5d2e09696fL20-R20) [[4]](diffhunk://#diff-e402d4d6a386818bd192cd9e2b7cac003fd7b6cbbe49574ca3a6fe5d2e09696fL60-R60) [[5]](diffhunk://#diff-e402d4d6a386818bd192cd9e2b7cac003fd7b6cbbe49574ca3a6fe5d2e09696fL117-R117) [[6]](diffhunk://#diff-e402d4d6a386818bd192cd9e2b7cac003fd7b6cbbe49574ca3a6fe5d2e09696fL178-R178) [[7]](diffhunk://#diff-e402d4d6a386818bd192cd9e2b7cac003fd7b6cbbe49574ca3a6fe5d2e09696fL236-R236)

### Removal of `browserWindowWithRetry` function:

* `src/general_helpers.ts` and `README.md`: Removed the `browserWindowWithRetry` function and its documentation, as it is no longer needed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L124-L127) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L343-L364) [[3]](diffhunk://#diff-0ee7f2fb85f231ef6a5e1c76c07e5802ab0d407703549bd86619754eba179a9dL50-L75)

### Test suite enhancements:

* [`example-project/e2e-tests/e2e.spec.ts`](diffhunk://#diff-ecef3eff4928fd029e70c5e367d2a2562ba44483fa63fd640a883f00cc9b312fR440-R485): Added new tests for the `retryUntilTruthy` function to verify its behavior under different conditions.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L124-L127): Updated documentation to reflect changes in retry options and removed references to the `browserWindowWithRetry` function. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L124-L127) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L343-L364) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L823-R798)

### Import adjustments:

* [`example-project/e2e-tests/e2e.spec.ts`](diffhunk://#diff-ecef3eff4928fd029e70c5e367d2a2562ba44483fa63fd640a883f00cc9b312fR29): Added import for `retryUntilTruthy` to ensure it is available for use in the test suite.