### PR TITLE
docs: add CLAUDE.md with commands and architecture notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`electron-playwright-helpers` — an npm library of helper functions for testing Electron apps with Playwright. Published from `src/` → `dist/`. Node 18+ required (uses `structuredClone()`).
+
+## Commands
+
+Two separate npm projects: the library at the root, and `example-project/` (an electron-forge app used as the e2e fixture). Both need installing:
+
+```bash
+npm ci && cd example-project && npm ci
+```
+
+| Task | Command |
+| --- | --- |
+| Build (compile + regenerate README) | `npm run make` |
+| Compile only | `npm run make:compile` |
+| Unit tests (mocha + chai, no Electron) | `npm run test:unit` |
+| Single unit test | `npx mocha --require ts-node/register --timeout 5000 './test/**/*.ts' --exit --grep "retry"` |
+| E2E tests (packages the app first via `pree2e`) | `npm run test:e2e` |
+| Single e2e test | `cd example-project && npx playwright test -g "test name"` |
+| E2E without repackaging | `cd example-project && npx playwright test` |
+| Lint / fix | `npm run lint` / `npm run lint:fix` |
+| Types | `npm run type-check` |
+
+`npm test` runs unit then e2e. E2E needs a packaged build in `example-project/out/` — `npm run package` (electron-forge) creates it, and `findLatestBuild()` locates it at test time. On Linux/CI, e2e runs under `xvfb-run` (see `.github/workflows/e2e-ci.yml`).
+
+**README.md is generated** — `npm run make:doc` renders `readme-template.hbs.md` + JSDoc from `src/*.ts` via jsdoc2md. Never hand-edit README.md; edit the template or the JSDoc comments.
+
+Releases are automatic: semantic-release on `main` (and prerelease on `beta`) driven by Conventional Commit messages. Don't bump versions manually or edit `docs/CHANGELOG.md`.
+
+## Architecture
+
+Every helper is a thin wrapper around `electronApp.evaluate()` or `page.evaluate()`, and nearly all of them are wrapped in `retry()`. `src/index.ts` just re-exports each module.
+
+### `retry()` is the backbone — `src/utilities.ts`
+
+Since Electron 27, Playwright's `evaluate()` throws spurious context errors. `retry()` retries *only* errors whose message matches `retryDefaults.errorMatch` in `src/utilities.ts` — a list of substrings taken from Playwright's own messages — and rethrows everything else immediately.
+
+**Those substrings are coupled to Playwright's internals**, specifically `rewriteError()` in `crExecutionContext.ts`, which rewrites raw CDP errors into user-facing ones. When Playwright rewords a message the list stops matching, and the symptom downstream is "sudden flakiness" after a Playwright upgrade. Read that function in the installed `playwright-core` before concluding a helper is at fault. The fix belongs in the `errorMatch` list, not in individual helpers, and should be additive — older Playwright versions may still emit the previous wording. `setRetryOptions()` / `getRetryOptions()` / `resetRetryOptions()` mutate a module-level singleton (`currentRetryOptions`), so changes are global and persist across tests until reset.
+
+`retryUntilTruthy()` layers polling-for-truthiness on top of `retry()`; its `retry*`-prefixed options are forwarded to the inner `retry()` call.
+
+### The evaluate boundary rules everything
+
+Code inside an `evaluate()` callback is serialized and executed inside the Electron process. Consequences that shape the whole codebase:
+
+- **No closures over module scope.** Any helper the callback needs must be declared *inside* the callback (see `cleanMenuItem` nested in `getMenuItemById`, `src/menu_helpers.ts`).
+- **Only serializable data crosses.** Hence the `*Partial` / `Serialized*` types: `MenuItemPartial` strips functions and circular refs, `SerializedNativeImage` turns a `NativeImage` into a data URL, and `toSerializableMatcher()` (`src/dialog_matchers.ts`) converts RegExp matchers to `{source, flags}` so they survive the trip and get rebuilt on the other side.
+- Type assertions and `@ts-ignore` are common at these boundaries by necessity.
+
+### Module map
+
+- `utilities.ts` — `retry`, `retryUntilTruthy`, retry option singleton, `addTimeout*`, `errToString`, `isRetryOptions`.
+- `general_helpers.ts` — `evaluateWithRetry`, `electronWaitForFunction` (the main-process analogue of `page.waitForFunction()`); menu/window waiters build on it.
+- `ipc_helpers.ts` — renderer-side (`ipcRendererSend/Invoke/Emit/CallFirstListener`) and main-side (`ipcMainEmit`, `ipcMainCallFirstListener`, `ipcMainInvokeHandler`). `ipcMainInvokeHandler` reaches into Electron's private `ipcMain._invokeHandlers` map and handles both the Electron ≤24 (`event._reply`) and ≥25 (return value) shapes.
+- `menu_helpers.ts` — click/read/wait on application menu items; does the serialization work described above.
+- `dialog_helpers.ts` — `stubDialog` / `stubMultipleDialogs` / `stubAllDialogs` monkeypatch methods on Electron's `dialog` module in the main process so no real dialog opens.
+- `dialog_matchers.ts` — conditional stubbing (`stubDialogMatchers` / `clearDialogMatchers`): match on the dialog's options (title, message, buttons…) and return different values per match.
+- `window_helpers.ts` — `getWindowBy{Url,Title,Matcher}` and `waitForWindowBy*`, with overloads returning one `Page` or all matches.
+- `find_parse_builds.ts` — pure Node (`fs` + `@electron/asar`), no Playwright. `findLatestBuild()` picks the newest hyphen-delimited platform dir under `out/`; `parseElectronApp()` reads the packaged app (including inside `app.asar`) and returns executable/main paths.
+
+### Variadic + options arg pattern
+
+IPC helpers take `...args: (unknown | RetryOptions)[]` and sniff the last argument with `isRetryOptions()` to decide whether it's retry options or a real IPC argument. `isRetryOptions()` returns true when *every* key of the object is a valid retry-option key — so adding a new field to `RetryOptions` widens what gets swallowed as options rather than passed to the app.
+
+## Tests
+
+- `test/*.ts` — unit tests (mocha + chai, config in `.mocharc.json`). They cover `retry`, `retryUntilTruthy`, and utilities; no Electron involved.
+- `example-project/e2e-tests/*.spec.ts` — Playwright tests that import **`../../src`, not `dist`** (with `// <-- replace with 'electron-playwright-helpers'` comments, since these files double as user-facing examples). Editing `src/` changes e2e behavior without a rebuild. `example-project/e2e-tests/app-manager.ts` shares the launched `ElectronApplication` across spec files.
+- `example-project/playwright.config.ts` uses `workers: 1`; the root `playwright.config.ts` points at the same testDir for running e2e from the repo root or VS Code (`.vscode/launch.json` has an "E2E Tests" config).
+
+## Style
+
+Prettier (no semicolons, single quotes, 2 spaces) enforced via eslint-plugin-prettier — run `npm run lint:fix`. `@typescript-eslint/no-explicit-any` and `ban-ts-comment` are off; the evaluate boundary needs them.


### PR DESCRIPTION
Adds a `CLAUDE.md` at the repo root so agents (and new contributors) start with the things that take a few files to work out.

What it documents:

- **Two npm projects.** The library at the root and `example-project/` both need installing, and E2E needs a packaged build via electron-forge.
- **The E2E suite imports `../../src`, not `dist`** — source edits take effect without a rebuild, which is not obvious from the layout.
- **README.md is generated** from JSDoc via jsdoc2md. Edit `readme-template.hbs.md` or the JSDoc and run `npm run make:doc`; never edit README.md directly.
- **`retry()`'s `errorMatch` list is coupled to Playwright's `rewriteError()`** in `crExecutionContext.ts`. That coupling is exactly what caused #106, so the file says to read that function before blaming a helper, and to keep the list additive.
- **The `evaluate()` boundary.** Callbacks are serialized into the Electron process, so they cannot close over module scope and only serializable data crosses. That is why `cleanMenuItem` is nested inside its callback and why `MenuItemPartial`, `SerializedNativeImage` and `toSerializableMatcher()` exist.
- **Releases are semantic-release** from Conventional Commits — versions and `docs/CHANGELOG.md` are not hand-edited.

Kept out of #106 deliberately so that PR stays a single behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QTJQHi1uUiiqiwuBwo6Jr

<!-- claude-session:d30aa0fc-45d9-4522-9985-4afe5f7e96ae -->
🔖 **Claude agent:** electron-playwright-helpers-30  
session id: `d30aa0fc-45d9-4522-9985-4afe5f7e96ae`