### PR TITLE
fix: give electronWaitForFunction a real timeout instead of looping forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,9 @@ and the path to the app's main file.</p>
 <dd><p>Wait for a function to evaluate to true in the main Electron process. This really
 should be part of the Playwright API, but it's not.</p>
 <p>This function is to <code>electronApp.evaluate()</code>
-as <code>page.waitForFunction()</code> is <code>page.evaluate()</code>.</p></dd>
+as <code>page.waitForFunction()</code> is <code>page.evaluate()</code>.</p>
+<p>Gives up once <code>options.timeout</code> has elapsed, so a function that never returns
+true rejects rather than polling forever.</p></dd>
 <dt><a href="#evaluateWithRetry">evaluateWithRetry(electronApp, fn, arg, retries, retryIntervalMs)</a> ⇒ <code>Promise.&lt;R&gt;</code></dt>
 <dd><p>Electron's <code>evaluate</code> function can be flakey,
 throwing an error saying the execution context has been destroyed.
@@ -571,15 +573,26 @@ and the path to the app's main file.</p>
 should be part of the Playwright API, but it's not.</p>
 <p>This function is to <code>electronApp.evaluate()</code>
 as <code>page.waitForFunction()</code> is <code>page.evaluate()</code>.</p>
+<p>Gives up once <code>options.timeout</code> has elapsed, so a function that never returns
+true rejects rather than polling forever.</p>
 
 **Kind**: global function  
+**Throws**:
+
+- <code>Error</code> <p>if the function has not returned true before <code>options.timeout</code> elapses</p>
+
 **Fulfil**: <code>void</code> Resolves when the function returns true  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| electronApp | <code>ElectronApplication</code> | <p>the Playwright ElectronApplication</p> |
-| fn | <code>function</code> | <p>the function to evaluate in the main process - must return a boolean</p> |
-| arg | <code>Any</code> | <p>optional - an argument to pass to the function</p> |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| electronApp | <code>ElectronApplication</code> |  | <p>the Playwright ElectronApplication</p> |
+| fn | <code>function</code> |  | <p>the function to evaluate in the main process - must return a boolean</p> |
+| arg | <code>Any</code> |  | <p>optional - an argument to pass to the function</p> |
+| [options.timeout] | <code>number</code> | <code>5000</code> | <p>how long to keep polling, in total, before giving up</p> |
+| [options.poll] | <code>number</code> | <code>100</code> | <p>how long to wait between polls after a falsy result</p> |
+| [options.retryTimeout] | <code>number</code> | <code>5000</code> | <p>how long a single <code>evaluate()</code> may take before it is retried</p> |
+| [options.retryPoll] | <code>number</code> | <code>200</code> | <p>how long to wait before retrying after an error</p> |
+| [options.retryErrorMatch] | <code>string</code> \| <code>Array.&lt;string&gt;</code> \| <code>RegExp</code> |  | <p>errors to retry. Others throw immediately</p> |
 
 <a name="evaluateWithRetry"></a>
 

--- a/src/general_helpers.ts
+++ b/src/general_helpers.ts
@@ -1,6 +1,11 @@
 import type { ElectronApplication } from 'playwright-core'
 import type { PageFunctionOn } from 'playwright-core/types/structs'
-import { retry, RetryOptions } from './utilities'
+import {
+  retry,
+  retryUntilTruthy,
+  RetryOptions,
+  RetryUntilTruthyOptions,
+} from './utilities'
 
 /**
  * Wait for a function to evaluate to true in the main Electron process. This really
@@ -9,24 +14,40 @@ import { retry, RetryOptions } from './utilities'
  * This function is to `electronApp.evaluate()`
  * as `page.waitForFunction()` is `page.evaluate()`.
  *
+ * Gives up once `options.timeout` has elapsed, so a function that never returns
+ * true rejects rather than polling forever.
+ *
  * @param electronApp {ElectronApplication} - the Playwright ElectronApplication
  * @param fn {Function} - the function to evaluate in the main process - must return a boolean
  * @param arg {Any} optional - an argument to pass to the function
+ * @param {number} [options.timeout=5000] - how long to keep polling, in total, before giving up
+ * @param {number} [options.poll=100] - how long to wait between polls after a falsy result
+ * @param {number} [options.retryTimeout=5000] - how long a single `evaluate()` may take before it is retried
+ * @param {number} [options.retryPoll=200] - how long to wait before retrying after an error
+ * @param {string|string[]|RegExp} [options.retryErrorMatch] - errors to retry. Others throw immediately
  * @returns {Promise<void>}
  * @fulfil {void} Resolves when the function returns true
+ * @throws {Error} if the function has not returned true before `options.timeout` elapses
  */
 export async function electronWaitForFunction<R, Arg>(
   electronApp: ElectronApplication,
   fn: PageFunctionOn<typeof Electron.CrossProcessExports, Arg, R>,
   arg?: Arg,
-  options: Partial<RetryOptions> = {}
+  options: Partial<RetryUntilTruthyOptions & RetryOptions> = {}
 ): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  while (!(await retry(() => electronApp.evaluate(fn, arg), options))) {
-    // wait 100ms before trying again
-    await new Promise((resolve) => setTimeout(resolve, 100))
-  }
+  // `errorMatch` and `disable` used to reach the inner retry() directly, since
+  // this took RetryOptions. Keep honoring them under their retry* names.
+  const { errorMatch, disable, ...rest } = options
+  await retryUntilTruthy(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    () => electronApp.evaluate(fn, arg),
+    {
+      ...rest,
+      ...(errorMatch !== undefined && { retryErrorMatch: errorMatch }),
+      ...(disable !== undefined && { retryDisable: disable }),
+    }
+  )
 }
 
 /**

--- a/test/general_helpers.test.ts
+++ b/test/general_helpers.test.ts
@@ -1,0 +1,67 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import type { ElectronApplication } from 'playwright-core'
+import { electronWaitForFunction } from '../src/general_helpers'
+
+chai.use(chaiAsPromised)
+
+/** the only thing electronWaitForFunction() touches is evaluate() */
+function fakeApp(evaluate: () => Promise<unknown>): ElectronApplication {
+  return { evaluate } as unknown as ElectronApplication
+}
+
+describe('electronWaitForFunction', () => {
+  it('should resolve once the function returns true', async () => {
+    let calls = 0
+    const app = fakeApp(async () => ++calls >= 3)
+
+    await electronWaitForFunction(app, () => true, undefined, {
+      timeout: 1000,
+      poll: 2,
+    })
+
+    expect(calls).to.equal(3)
+  })
+
+  it('should give up rather than polling forever', async () => {
+    // a function that is never going to be true used to spin until Playwright's
+    // own test timeout killed the run, with no indication of what was stuck
+    const app = fakeApp(async () => false)
+
+    await expect(
+      electronWaitForFunction(app, () => false, undefined, {
+        timeout: 50,
+        poll: 2,
+      })
+    ).to.be.rejectedWith('Timeout')
+  })
+
+  it('should still honor errorMatch, which used to reach retry() directly', async () => {
+    let calls = 0
+    const app = fakeApp(async () => {
+      if (++calls < 3) {
+        throw new Error('flaky thing happened')
+      }
+      return true
+    })
+
+    await electronWaitForFunction(app, () => true, undefined, {
+      timeout: 1000,
+      poll: 2,
+      retryPoll: 2,
+      errorMatch: 'flaky thing happened',
+    })
+
+    expect(calls).to.equal(3)
+  })
+
+  it('should throw an unmatched error instead of swallowing it', async () => {
+    const app = fakeApp(async () => {
+      throw new Error('No application menu found')
+    })
+
+    await expect(
+      electronWaitForFunction(app, () => true, undefined, { timeout: 50 })
+    ).to.be.rejectedWith('No application menu found')
+  })
+})


### PR DESCRIPTION
## The problem

`electronWaitForFunction()` polled in an unbounded `while` loop:

```ts
while (!(await retry(() => electronApp.evaluate(fn, arg), options))) {
  await new Promise((resolve) => setTimeout(resolve, 100))
}
```

If the evaluated function never returned true, this span forever. The only thing that stopped it was Playwright's own test timeout, which reports that the *test* timed out and says nothing about which wait was stuck.

The `options.timeout` it accepted did not help: it was passed to the inner `retry()`, so it bounded a single `evaluate()` round trip, not the wait as a whole. There was no way to bound the wait from the outside.

Both in-repo callers — `waitForMenuItem()` and `waitForMenuItemStatus()` in `src/menu_helpers.ts` — pass no options at all, so they inherited the unbounded behavior.

## The fix

`retryUntilTruthy()` already does this exact job: poll for a truthy value with an overall timeout, forwarding `retry*`-prefixed options to an inner `retry()`. Rather than keep a second, unbounded implementation of the same loop, `electronWaitForFunction()` now delegates to it.

## Behavior change

`timeout` and `poll` now mean what their names suggest:

| option | before | after |
| --- | --- | --- |
| `timeout` | max time for one `evaluate()` | **total** time to keep polling (default 5000ms) |
| `poll` | gap between error retries | gap between polls after a falsy result (default 100ms — the value previously hardcoded) |
| `retryTimeout` | — | max time for one `evaluate()` |
| `retryPoll` | — | gap between error retries |
| `retryErrorMatch` | — | which errors to retry |

`errorMatch` and `disable` previously reached `retry()` directly, because the function took `RetryOptions`. They are still accepted and are mapped to `retryErrorMatch` / `retryDisable`, so existing calls keep compiling and keep their meaning.

The practical effect for anyone passing `{ timeout: n }` today is that `n` now bounds the whole wait instead of one round trip — which is what the name implies and, in a function whose job is waiting, almost certainly what was intended.

## Tests

New `test/general_helpers.test.ts` covers the four cases, using a stub object for `ElectronApplication` since the helper only ever touches `.evaluate()`:

- resolves once the function returns true
- **gives up rather than polling forever** — this one hangs until mocha's timeout on the old code
- `errorMatch` still reaches the inner `retry()`
- an unmatched error still throws instead of being swallowed

43 unit tests passing, `tsc --noEmit` clean, ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QTJQHi1uUiiqiwuBwo6Jr

<!-- claude-session:c33aa60a-c4d9-44c2-8cd0-da1edaceb739 -->
🔖 **Claude agent:** electron-playwright-helpers-30  
session id: `c33aa60a-c4d9-44c2-8cd0-da1edaceb739`