### PR TITLE
ci: modernize GitHub Actions workflows and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/example-project"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -5,7 +5,35 @@ on: [pull_request]
 env:
   GITHUB_PR_NUMBER: ${{github.event.pull_request.number}}
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint_and_unit:
+    name: Lint, type-check, and unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            example-project/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Type check
+        run: npm run type-check
+      - name: Unit tests
+        run: npm run test:unit
+
   tests_e2e:
     name: Run end-to-end tests
     runs-on: ${{ matrix.os }}
@@ -14,18 +42,24 @@ jobs:
       matrix:
         # Playwright >= 1.62 requires Node 20+. The library itself still supports
         # Node 18 - only the test toolchain needs a newer runtime.
-        node_version: [20, 22]
-        os: [ubuntu-latest, windows-latest]
+        node_version: [20, 22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             commandPrefix: 'xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24 +extension GLX +render -noreset" --'
           - os: windows-latest
             commandPrefix: ''
+          - os: macos-latest
+            commandPrefix: ''
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node_version }}
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            example-project/package-lock.json
       - name: Install system dependencies (Ubuntu)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
@@ -43,11 +77,5 @@ jobs:
             libasound2-dev
       - name: Install dependencies
         run: npm ci && cd example-project && npm ci
-      - name: Lint
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        run: npm run lint
       - name: e2e tests
-        run: ${{ matrix.commandPrefix }} npm test
-
-
-
+        run: ${{ matrix.commandPrefix }} npm run test:e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,31 @@ on:
     branches:
       - main
       - beta
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: "lts/*"
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Build (update README.md)


### PR DESCRIPTION
Part of a maintenance sweep. This PR touches **only `.github/`** — no dependency or source changes, so it can merge independently of the others.

## Why

- Workflows were pinned to `actions/checkout@v3` / `actions/setup-node@v3` (current is v7).
- No npm caching, so every job re-downloaded both dependency trees.
- Lint + unit tests ran inside every e2e matrix cell, so a lint error cost a full Electron packaging run on every OS.
- No `.github/dependabot.yml` at all. That's why the repo accumulated **18 ungrouped open Dependabot PRs**, 15 of which are lockfile-only transitive bumps.

## Changes

### `e2e-ci.yml`
- Split into two jobs: a fast `lint_and_unit` (ubuntu, Node 22) that runs lint + type-check + unit tests, and `tests_e2e` which now runs only `npm run test:e2e`.
- Matrix widened to Node `[20, 22, 24]` × `[ubuntu, windows, macos]`. macOS runners are free for public repos, and this library is used heavily on macOS — it was previously untested there.
- `actions/checkout@v7`, `actions/setup-node@v7`, npm caching keyed on both lockfiles.
- Added `concurrency` (cancel superseded PR runs) and `permissions: contents: read`.
- The ubuntu-only xvfb prefix and apt system-deps step are unchanged and still correctly gated.

### `release.yml`
- Same action bumps + npm cache.
- Explicit `permissions` for semantic-release (`contents`/`issues`/`pull-requests: write`, plus `id-token: write` for npm provenance).
- `concurrency` with `cancel-in-progress: false` so two releases can't race.

### `dependabot.yml` (new)
Weekly, three ecosystems (npm root, npm `example-project`, github-actions), `open-pull-requests-limit: 5`, with **grouped** minor/patch updates so transitive bumps arrive as one PR per group instead of fifteen. Majors still come through individually. Commit prefixes are `chore(deps)` / `chore(deps-dev)`, which `.releaserc.json` does not map to a release — so lockfile bumps won't cut a version.

## Notes

- **Node 20 reached EOL on 2026-04-30.** It's kept in the matrix here because `engines` still says `>=18`; it gets dropped in the separate PR that raises the engine floor.
- `GITHUB_PR_NUMBER` is retained. Nothing in the repo references it, but I couldn't prove it's unused by an external reporter, so I left it.

Action versions were verified against the GitHub API; all three YAML files parse.

<!-- claude-session:515d819e-6f5b-44e2-a424-d9bcd97d1298 -->
🔖 **Claude agent:** electron-playwright-helpers-03  
session id: `515d819e-6f5b-44e2-a424-d9bcd97d1298`