### PR TITLE
fix: show docs, refactor, test and style commits in the changelog

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -32,7 +32,27 @@
         ]
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance Improvements" },
+            { "type": "revert", "section": "Reverts" },
+            { "type": "docs", "section": "Documentation" },
+            { "type": "refactor", "section": "Code Refactoring" },
+            { "type": "test", "section": "Tests" },
+            { "type": "style", "section": "Styles" },
+            { "type": "build", "hidden": true },
+            { "type": "ci", "hidden": true },
+            { "type": "chore", "hidden": true }
+          ]
+        }
+      }
+    ],
     [
       "@semantic-release/changelog",
       {


### PR DESCRIPTION
Follow-up from the review of #117. **Stacked on #117** — merge that first.

## The bug

`.releaserc.json` configures `commit-analyzer` with custom `releaseRules`:

```
docs -> patch    refactor -> patch    style -> patch    test -> patch
```

But `release-notes-generator` was listed as a bare string with **no options**, so it fell back to its default `angular` preset. And both angular *and* conventionalcommits **hide those four types by default**.

Net effect: a `docs:` or `refactor:` or `test:` or `style:` commit cuts a real patch release whose CHANGELOG entry and GitHub release body contain **no section describing it** — a version number appears with nothing to explain why. Given `docs`, `refactor`, `style` and `test` were deliberately added to `releaseRules`, that's clearly not the intent.

Verified against the current config before changing anything — feeding one commit of each type through the existing setup renders only Features, Bug Fixes and Performance Improvements. The other four vanish.

## The fix

Configure `release-notes-generator` with the `conventionalcommits` preset so it agrees with `commit-analyzer`, plus an explicit `presetConfig.types` list that unhides exactly the four types `releaseRules` acts on. `build`, `ci` and `chore` stay hidden, which matches them triggering no release.

Note that **switching the preset alone would not have fixed this** — both presets hide those types. The explicit `types` list is the actual fix.

Verified by rendering commits of every type through the config read directly out of `.releaserc.json`:

```
### Features              ### Documentation
### Bug Fixes             ### Code Refactoring
### Performance …         ### Tests
                          ### Styles
```

…and `chore:`/`ci:` commits produce nothing. `npx semantic-release --dry-run` loads the config with no errors.

## One cosmetic change

The conventionalcommits preset uses `## [version]` where angular used `# [version]`, so future CHANGELOG entries sit one heading level deeper. Existing entries are untouched.

## Dependency note

This makes the `conventional-changelog-conventionalcommits@^9` pin from #117 **load-bearing**. Under `^10` the preset renders a bare version header with no sections at all (semantic-release 25 bundles `conventional-changelog-writer` 8; v10 moved the templates it reads). Before this PR that pin only mattered hypothetically, since the preset was unused. Now it matters — a future major bump of that preset must be refused until `release-notes-generator` ships writer v9.

<!-- claude-session:515d819e-6f5b-44e2-a424-d9bcd97d1298 -->
🔖 **Claude agent:** electron-playwright-helpers-03  
session id: `515d819e-6f5b-44e2-a424-d9bcd97d1298`