### PR TITLE
test: cover the retry() branch that refuses to report success

### DIFF
--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -191,6 +191,41 @@ describe('retry', () => {
       })
     })
 
+    it('should throw a matching error that is not a teardown error', async () => {
+      let counter = 0
+      const fn = async () => {
+        counter++
+        throw new Error('flaky thing happened')
+      }
+
+      // the error matches, so it isn't "your code is broken", but it also isn't
+      // teardown - the context is still there, so nothing tells us whether the
+      // action fired. Reporting success here would pass a test that never ran.
+      await assert.rejects(
+        retry(fn, { disable: true, errorMatch: 'flaky thing' }),
+        { message: /flaky thing happened/ },
+      )
+
+      assert.strictEqual(counter, 1)
+    })
+
+    it('should throw a garbage-collected promise error the caller opted into retrying', async () => {
+      const fn = async () => {
+        throw new Error(GC_ERROR)
+      }
+
+      // opting into retrying GC errors takes them past the explain-and-throw
+      // path, but disable: true means there is no retry left to make - and the
+      // callback body already ran, so success is exactly what we can't claim
+      await assert.rejects(
+        retry(fn, {
+          disable: true,
+          errorMatch: 'promise was garbage collected',
+        }),
+        { message: /Resulting promise was garbage collected\./ },
+      )
+    })
+
     it('should be honored when set globally via setRetryOptions()', async () => {
       setRetryOptions({ disable: true })
       let counter = 0


### PR DESCRIPTION
Follow-up from the review of the modernization stack. **Stacked on #118** — merge that first.

## The gap

`src/utilities.ts:349-352` — inside `retry()`'s catch, the path whose comment states the invariant outright:

```js
// errorMatch - means we don't know whether the action happened.
// Throw rather than silently reporting success.
throw err
```

Nothing exercised it. Replacing that `throw err` with `return` left **50 passing, 0 failing**.

This is worth covering more than a typical coverage hole: silently reporting success here would make a downstream user's test pass when the operation never actually happened — the exact failure this library exists to prevent.

## Why it was unreachable

Reaching it requires all four of:

1. `disable: true`
2. the error message **matches** `errorMatch`
3. the error message does **not** match `teardownErrorMatch` (or it gets swallowed at line 347)
4. …which implies **`errorMatch` must be custom** — because `retryDefaults.errorMatch` is literally `[...teardownErrorMatch]` (line 377). Under defaults, "matches errorMatch" and "is a teardown error" are the *same set*, so the branch cannot be reached at all.

That's why no existing test touched it. Worth knowing on its own: this branch only ever runs for users who set their own `errorMatch`.

Also confirmed the existing `should throw a garbage-collected promise error rather than report success` does **not** reach it — a GC error fails the `errorMatch` gate under defaults and throws earlier via `explainGcError()`.

## Tests added (2, both in the existing `describe('disable')`)

- **`should throw a matching error that is not a teardown error`** — custom `errorMatch: 'flaky thing'` + `disable: true`. Asserts it rejects and the function ran exactly once.
- **`should throw a garbage-collected promise error the caller opted into retrying`** — `errorMatch: 'promise was garbage collected'` + `disable: true`. Opting in pushes the GC error past the explain-and-throw path so it lands on the same `throw err`. That interaction was untested.

Sibling branches were already covered and nothing was added for them: the teardown swallow, the non-matching throw, and the `break`.

## Mutation check

`throw err` → `return`:

```
50 passing, 2 failing
  1) disable > should throw a matching error that is not a teardown error:
     AssertionError [ERR_ASSERTION]: Missing expected rejection.
  2) disable > should throw a garbage-collected promise error the caller opted into retrying:
     AssertionError [ERR_ASSERTION]: Missing expected rejection.
```

Exactly the two new tests fail and the other 50 stay green — confirming both that they pin the behavior and that no pre-existing test was touching that line. Source reverted; `git diff src/` is empty.

**52 passing** (was 50). `tsc --noEmit`, `lint`, and `prettier --check 'test/**/*.ts'` all clean.

<!-- claude-session:515d819e-6f5b-44e2-a424-d9bcd97d1298 -->
🔖 **Claude agent:** electron-playwright-helpers-03  
session id: `515d819e-6f5b-44e2-a424-d9bcd97d1298`