### PR TITLE
feat: explain more errors, with the fix to make, not just the symptom

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,6 +902,11 @@ this to retrieve test data from the main process.</p>
 
 **Kind**: global function  
 **Category**: IPCMain  
+**Throws**:
+
+- <code>Error</code> <p>if no handler is registered for the channel, with an
+explanation of the usual causes appended</p>
+
 **Fulfil**: <code>unknown</code> resolves with the result of the function called in main process  
 
 | Param | Type | Description |

--- a/src/error_help.ts
+++ b/src/error_help.ts
@@ -1,0 +1,232 @@
+/**
+ * Explanatory text attached to errors whose own message names a symptom
+ * without naming a cause or a fix, plus the machinery which attaches it.
+ *
+ * This module deliberately imports nothing. `find_parse_builds.ts` is pure
+ * Node with no Playwright in it, and `utilities.ts` pulls in the whole of
+ * `index.ts`, so a shared leaf module is the only place both can reach
+ * without creating a require cycle.
+ *
+ * **Nothing here may contain a string from {@link teardownErrorMatch} or
+ * {@link gcErrorMatch}.** Help text is appended to the error's own message,
+ * and `retry()` matches those lists against the whole message, so a stray
+ * quote would turn an error that should throw immediately into one that gets
+ * retried - re-firing whatever side effects the call already had. There is a
+ * unit test for exactly this.
+ *
+ * @ignore
+ */
+
+/**
+ * Errors which mean the execution context went away *after* the call was
+ * dispatched, i.e. the action most likely happened, and only the reply was
+ * lost. When retries are disabled these are swallowed rather than thrown.
+ *
+ * @ignore
+ */
+export const teardownErrorMatch = [
+  'context or browser has been closed',
+  // Execution context was destroyed, most likely because of a navigation.
+  'Execution context was destroyed',
+  // "Cannot read properties of undefined (reading 'getOwnerBrowserWindow')"
+  `reading 'getOwnerBrowserWindow'`,
+]
+
+/**
+ * Errors which mean V8 garbage-collected the promise that Playwright was awaiting.
+ *
+ * Playwright sends `Runtime.callFunctionOn` with `awaitPromise: true`, and V8's
+ * inspector tracks the promise it is awaiting through a *weak* handle
+ * (`ProtocolPromiseHandler` in `v8/src/inspector/injected-script.cc`). If that
+ * promise becomes unreachable in the target heap before it settles, the weak
+ * callback fires and CDP answers "Promise was collected". Playwright >= 1.62
+ * rewrites that to "Resulting promise was garbage collected."
+ * (`crExecutionContext.ts::rewriteError`).
+ *
+ * In practice only the rewritten wording ever reaches a caller: Playwright
+ * >= 1.62 replaces the error outright, and Playwright < 1.62 has no branch for
+ * the raw message at all, so it falls through `rewriteError`'s catch-all and
+ * arrives disguised as a teardown error - i.e. on those versions a collected
+ * promise is still retried. The raw wording is kept here anyway, in case it is
+ * ever surfaced directly.
+ *
+ * This is **not** a transient failure and is deliberately NOT in
+ * `retryDefaults.errorMatch` - see the note on `retry()`.
+ *
+ * @ignore
+ */
+export const gcErrorMatch = [
+  'Promise was collected',
+  'promise was garbage collected',
+]
+
+/**
+ * Attach explanatory text to an error.
+ *
+ * Appends to the original error rather than wrapping it, so its identity and
+ * stack survive. `.stack` has to be rebuilt from its own frames afterwards:
+ * V8 renders it lazily and then caches it, so a `.stack` that was already read
+ * would keep the old message and the note would never appear in whatever a
+ * test reporter prints. Playwright does the same dance in `rewriteErrorMessage()`.
+ *
+ * @param err - the error to explain. Non-Errors are replaced by a real Error,
+ *   since there is nothing to append to.
+ * @param help - the text to append, from this module
+ * @param errString - a string rendering of `err`, used only for the non-Error case
+ *
+ * @ignore
+ */
+export function explainError(
+  err: unknown,
+  help: string,
+  errString = String(err),
+): unknown {
+  if (!(err instanceof Error)) {
+    return new Error(`${errString}\n\n${help}`)
+  }
+  // helpers call retry() internally, so a retry() around a helper sees an error
+  // an inner retry() already explained - don't say it twice
+  if (err.message.includes(help)) {
+    return err
+  }
+  try {
+    err.message = `${err.message}\n\n${help}`
+  } catch {
+    // a frozen error, or a subclass whose `message` is getter-only. Assigning
+    // throws under "use strict" - the original error is worth more than the note
+    return err
+  }
+  const frames = (err.stack?.split('\n') || []).filter((line) =>
+    line.startsWith('    at '),
+  )
+  if (frames.length) {
+    err.stack = [`${err.name}: ${err.message}`, ...frames].join('\n')
+  }
+  return err
+}
+
+/**
+ * Every help string in this module, so the "must not contain a retry matcher"
+ * invariant can be tested over all of them at once. Add new help here too.
+ *
+ * @ignore
+ */
+export const errorHelp = {
+  /** appended to "Resulting promise was garbage collected." */
+  gc: [
+    'V8 collected the promise Playwright was awaiting before it could settle.',
+    'Two different things produce this, and they want opposite responses:',
+    '',
+    '1. An evaluate() callback returned a promise that nothing in the target',
+    '   process references - e.g. `evaluate(() => new Promise(() => {}))`. This is',
+    '   deterministic, not flaky: it fails the same way every time, so retrying',
+    '   only wastes the timeout. The callback body has ALREADY RUN - its side',
+    '   effects happened and only the reply was lost, so a retry fires them twice.',
+    '   Fix the callback: return a value, or a promise that something retains (an',
+    '   Electron API call, a timer, an event listener), rather than one nothing',
+    '   holds.',
+    '',
+    '2. A raw Playwright channel call - electronApp.browserWindow(),',
+    '   JSHandle.getProperty() and friends - lost an internal promise mid-flight.',
+    '   You wrote no callback here, so there is nothing to fix in your code. This',
+    '   one IS transient and worth retrying.',
+    '',
+    'The message is identical either way, so this library cannot tell them apart',
+    'and does not retry by default - silently repeating a side effect is the worse',
+    'failure. If yours is case 2, opt in per call. Note that errorMatch REPLACES',
+    'the default list rather than extending it, so repeat the defaults you still',
+    'want. See the README.',
+  ].join('\n'),
+
+  /** appended to `retry()`'s own timeout error */
+  retryTimeout: [
+    'retry() called the function until its timeout ran out. The "Last throw"',
+    'above is the error from the final attempt, and almost certainly from every',
+    'attempt before it, so that error is the thing to fix - this timeout is only',
+    'the symptom of it repeating.',
+    '',
+    'If the last throw is a real failure in your app or your test - a menu item',
+    'that does not exist, an IPC channel nobody registered, a window that never',
+    'opened - then retrying was never going to help. Fix that condition, or wait',
+    'for it explicitly with the matching waitFor* helper.',
+    '',
+    'If the app was simply slower than the timeout, raise it: pass',
+    '{ timeout: 15000 } to this call, or call setRetryOptions({ timeout: 15000 })',
+    'to raise it for every later call in this process, and resetRetryOptions()',
+    'to put it back.',
+    '',
+    'If retry() should be retrying an error it currently does not, list that',
+    'error in the errorMatch option. Note that errorMatch REPLACES the default',
+    'list rather than extending it, so repeat the defaults you still want. See',
+    'the README.',
+  ].join('\n'),
+
+  /** appended to `addTimeoutToPromise()`'s default timeout error */
+  addTimeout: [
+    'The promise did not settle in time. addTimeoutToPromise() only stops',
+    'waiting - it cannot cancel the work, which keeps running and may fail or',
+    'log on its own later, after the test that started it has moved on.',
+    '',
+    'Raise timeoutMs if the operation is legitimately slow. If you cannot tell',
+    'which call this was, pass timeoutMessage (the third argument to both',
+    'addTimeoutToPromise() and addTimeout()) to name it. If the promise never',
+    'settles at all, the problem is in the wrapped call rather than in the',
+    'timeout - await it directly, without addTimeoutToPromise(), to see the',
+    'error it produces on its own.',
+  ].join('\n'),
+
+  /** appended when `findLatestBuild()` finds no build directory */
+  findLatestBuild: [
+    'findLatestBuild() looks one level down for directories whose name contains',
+    'a hyphen-delimited platform - "my-app-darwin-arm64", "my-app-win32-x64" -',
+    'and returns the most recently modified one. It found none.',
+    '',
+    'Package the app before running the tests: "npm run package" with',
+    'electron-forge, or your packager of choice, and check that its output',
+    'landed in the directory named above. If your builds go somewhere else,',
+    'pass that directory: findLatestBuild("dist"). If your build directory name',
+    'contains no platform, skip this function and hand the path straight to',
+    'parseElectronApp("out/my-app").',
+  ].join('\n'),
+
+  /** appended when `parseElectronApp()` cannot read a platform from the dir name */
+  parsePlatform: [
+    'parseElectronApp() reads the platform out of the build directory name,',
+    'which has to contain one of win/win32/windows, darwin/mac/macos/osx or',
+    'linux/ubuntu/debian. That is what electron-forge and electron-packager',
+    'produce by default, e.g. "my-app-darwin-arm64".',
+    '',
+    'Either rename the build directory to include the platform, or point this',
+    'function straight at the app instead of at its parent directory - a path',
+    'ending in ".app" or ".exe" tells it the platform without any name parsing.',
+  ].join('\n'),
+
+  /** appended when `ipcMainInvokeHandler()` finds no registered handler */
+  ipcMainInvokeHandler: [
+    "ipcMainInvokeHandler() looks the channel up in ipcMain's private",
+    '_invokeHandlers map, which holds only the channels registered through',
+    'ipcMain.handle(). Nothing was registered under this one when the call ran.',
+    '',
+    'Check the channel name first - it is matched exactly, and calling',
+    'ipcMain.on() where you meant ipcMain.handle() puts the channel somewhere',
+    'this function cannot see. If the handler is registered lazily - inside',
+    'app.whenReady(), when a window opens, or in a module that has not been',
+    'imported yet - then the test simply got there first, so wait for whatever',
+    'triggers the registration before calling this. To call a channel that is',
+    'genuinely registered with ipcMain.on(), use ipcMainEmit() or',
+    'ipcMainCallFirstListener() instead.',
+  ].join('\n'),
+
+  /** appended when `waitForWindowBy*()` times out */
+  waitForWindow: [
+    'No window already open matched, and no window that opened during the wait',
+    'matched either.',
+    '',
+    'Print what the app actually has open before matching: electronApp.windows()',
+    'returns the current pages, and page.url() and await page.title() are the',
+    'exact values these helpers test. A window which has not finished navigating',
+    'reports an empty url and an empty title, so match on something that is set',
+    'early, or raise the timeout. String patterns match by substring and are',
+    'case-sensitive; a RegExp is tested as given, so check its anchors and flags.',
+  ].join('\n'),
+}

--- a/src/find_parse_builds.ts
+++ b/src/find_parse_builds.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import fs from 'fs'
 import * as ASAR from '@electron/asar'
+import { errorHelp, explainError } from './error_help'
 
 /**
  * Parses the `out` directory to find the latest build of your Electron project.
@@ -25,6 +26,14 @@ export function findLatestBuild(buildDirectory = 'out'): string {
   const rootDir = path.resolve('./')
   // directory where the builds are stored
   const outDir = path.resolve(rootDir, buildDirectory)
+  // a missing directory is the same user problem as an empty one - nothing has
+  // been packaged - so say the same thing, rather than leaking a bare ENOENT
+  if (!fs.existsSync(outDir)) {
+    throw explainError(
+      new Error(`Build directory does not exist: ${outDir}`),
+      errorHelp.findLatestBuild,
+    )
+  }
   // list of files in the out directory
   const builds = fs.readdirSync(outDir)
   const platforms = [
@@ -65,7 +74,10 @@ export function findLatestBuild(buildDirectory = 'out'): string {
       }
     })[0]
   if (!latestBuild) {
-    throw new Error('No build found in out directory')
+    throw explainError(
+      new Error(`No Electron build found in ${outDir}`),
+      errorHelp.findLatestBuild,
+    )
   }
   return path.join(outDir, latestBuild)
 }
@@ -175,7 +187,10 @@ export function parseElectronApp(buildDir: string): ElectronAppInfo {
   }
 
   if (!platform) {
-    throw new Error(`Platform not found in directory name: ${baseNameLc}`)
+    throw explainError(
+      new Error(`Platform not found in directory name: ${baseNameLc}`),
+      errorHelp.parsePlatform,
+    )
   }
 
   let arch: Architecture

--- a/src/ipc_helpers.ts
+++ b/src/ipc_helpers.ts
@@ -1,5 +1,6 @@
 import { ElectronApplication, Page } from 'playwright-core'
-import { isRetryOptions, retry, RetryOptions } from './utilities'
+import { errToString, isRetryOptions, retry, RetryOptions } from './utilities'
+import { errorHelp, explainError } from './error_help'
 
 /**
  * Send an `ipcRenderer.send()` (to main process) from a given window.
@@ -301,6 +302,8 @@ type IpcMainWithHandlers = Electron.IpcMain & {
  * @param retryOptions {RetryOptions} optional - options for retrying upon error
  * @returns {Promise<unknown>}
  * @fulfil {unknown} resolves with the result of the function called in main process
+ * @throws {Error} if no handler is registered for the channel, with an
+ *   explanation of the usual causes appended
  */
 export async function ipcMainInvokeHandler(
   electronApp: ElectronApplication,
@@ -342,5 +345,13 @@ export async function ipcMainInvokeHandler(
         { message, args },
       ),
     retryOptions,
-  )
+  ).catch((err: unknown) => {
+    // the throw above happens inside the evaluate() callback, which cannot see
+    // anything in this module, so the explanation is attached here instead
+    const errString = errToString(err)
+    if (errString.includes('No ipcMain handler registered')) {
+      throw explainError(err, errorHelp.ipcMainInvokeHandler, errString)
+    }
+    throw err
+  })
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,4 +1,10 @@
 import * as helpers from './'
+import {
+  errorHelp,
+  explainError,
+  gcErrorMatch,
+  teardownErrorMatch,
+} from './error_help'
 
 export type AllHelpers = typeof helpers
 
@@ -36,8 +42,13 @@ export async function addTimeoutToPromise<T>(
     setTimeout(() => {
       reject(
         timeoutMessage
-          ? new Error(timeoutMessage)
-          : new Error(`timeout after ${timeoutMs}ms`),
+          ? // a caller-supplied message is theirs - they already know what timed
+            // out, which is the only thing our note would have told them
+            new Error(timeoutMessage)
+          : explainError(
+              new Error(`timeout after ${timeoutMs}ms`),
+              errorHelp.addTimeout,
+            ),
       )
     }, timeoutMs)
     promise
@@ -101,113 +112,6 @@ export type RetryOptions = {
    * `setRetryOptions()` has the same runtime effect, but the types cannot see it.
    */
   disable: boolean
-}
-
-/**
- * Errors which mean the execution context went away *after* the call was dispatched,
- * i.e. the action most likely happened, and only the reply was lost. When retries are
- * disabled these are swallowed rather than thrown.
- *
- * @ignore
- */
-const teardownErrorMatch = [
-  'context or browser has been closed',
-  // Execution context was destroyed, most likely because of a navigation.
-  'Execution context was destroyed',
-  // "Cannot read properties of undefined (reading 'getOwnerBrowserWindow')"
-  `reading 'getOwnerBrowserWindow'`,
-]
-
-/**
- * Errors which mean V8 garbage-collected the promise that Playwright was awaiting.
- *
- * Playwright sends `Runtime.callFunctionOn` with `awaitPromise: true`, and V8's
- * inspector tracks the promise it is awaiting through a *weak* handle
- * (`ProtocolPromiseHandler` in `v8/src/inspector/injected-script.cc`). If that
- * promise becomes unreachable in the target heap before it settles, the weak
- * callback fires and CDP answers "Promise was collected". Playwright >= 1.62
- * rewrites that to "Resulting promise was garbage collected."
- * (`crExecutionContext.ts::rewriteError`).
- *
- * In practice only the rewritten wording ever reaches a caller: Playwright
- * >= 1.62 replaces the error outright, and Playwright < 1.62 has no branch for
- * the raw message at all, so it falls through `rewriteError`'s catch-all and
- * arrives disguised as "Execution context was destroyed" - i.e. on those
- * versions a collected promise is still retried, as a teardown error. The raw
- * wording is kept here anyway, in case it is ever surfaced directly.
- *
- * This is **not** a transient failure and is deliberately NOT in
- * {@link retryDefaults}.`errorMatch` - see the note on {@link retry}.
- *
- * @ignore
- */
-const gcErrorMatch = ['Promise was collected', 'promise was garbage collected']
-
-/**
- * Appended to a garbage-collected-promise error, because the raw message names
- * the symptom and not the cause.
- *
- * @ignore
- */
-const gcErrorHelp = [
-  'V8 collected the promise Playwright was awaiting before it could settle.',
-  'Two different things produce this, and they want opposite responses:',
-  '',
-  '1. An evaluate() callback returned a promise that nothing in the target',
-  '   process references - e.g. `evaluate(() => new Promise(() => {}))`. This is',
-  '   deterministic, not flaky: it fails the same way every time, so retrying',
-  '   only wastes the timeout. The callback body has ALREADY RUN - its side',
-  '   effects happened and only the reply was lost, so a retry fires them twice.',
-  '   Fix the callback: return a value, or a promise that something retains (an',
-  '   Electron API call, a timer, an event listener), rather than one nothing',
-  '   holds.',
-  '',
-  '2. A raw Playwright channel call - electronApp.browserWindow(),',
-  '   JSHandle.getProperty() and friends - lost an internal promise mid-flight.',
-  '   You wrote no callback here, so there is nothing to fix in your code. This',
-  '   one IS transient and worth retrying.',
-  '',
-  'The message is identical either way, so this library cannot tell them apart',
-  'and does not retry by default - silently repeating a side effect is the worse',
-  'failure. If yours is case 2, opt in per call. Note that errorMatch REPLACES',
-  'the default list rather than extending it, so repeat the defaults you still',
-  'want. See the README.',
-].join('\n')
-
-/**
- * Attach {@link gcErrorHelp} to a garbage-collected-promise error.
- *
- * Appends to the original error rather than wrapping it, so its identity and
- * stack survive. `.stack` has to be rebuilt from its own frames afterwards:
- * V8 renders it lazily and then caches it, so a `.stack` that was already read
- * would keep the old message and the note would never appear in whatever a
- * test reporter prints. Playwright does the same dance in `rewriteErrorMessage()`.
- *
- * @ignore
- */
-function explainGcError(err: unknown, errString: string): unknown {
-  if (!(err instanceof Error)) {
-    return new Error(`${errString}\n\n${gcErrorHelp}`)
-  }
-  // helpers call retry() internally, so a retry() around a helper sees an error
-  // an inner retry() already explained - don't say it twice
-  if (err.message.includes(gcErrorHelp)) {
-    return err
-  }
-  try {
-    err.message = `${err.message}\n\n${gcErrorHelp}`
-  } catch {
-    // a frozen error, or a subclass whose `message` is getter-only. Assigning
-    // throws under "use strict" - the original error is worth more than the note
-    return err
-  }
-  const frames = (err.stack?.split('\n') || []).filter((line) =>
-    line.startsWith('    at '),
-  )
-  if (frames.length) {
-    err.stack = [`${err.name}: ${err.message}`, ...frames].join('\n')
-  }
-  return err
 }
 
 /**
@@ -335,7 +239,7 @@ export async function retry<T>(
         // promise deserves an explanation, since its message names the symptom
         // rather than the cause
         if (errorMatches(errString, gcErrorMatch)) {
-          throw explainGcError(err, errString)
+          throw explainError(err, errorHelp.gc, errString)
         }
         throw err
       }
@@ -367,7 +271,10 @@ export async function retry<T>(
     }
   }
   const errMessage = lastErr ? ' Last throw: ' + errToString(lastErr) : ''
-  throw new Error(`retry()::Timeout after ${timeout}ms.${errMessage}`)
+  throw explainError(
+    new Error(`retry()::Timeout after ${timeout}ms.${errMessage}`),
+    errorHelp.retryTimeout,
+  )
 }
 
 const retryDefaults: RetryOptions = {

--- a/src/window_helpers.ts
+++ b/src/window_helpers.ts
@@ -1,5 +1,6 @@
 import type { ElectronApplication, Page } from 'playwright-core'
-import { retry, RetryOptions } from './utilities'
+import { errToString, retry, RetryOptions } from './utilities'
+import { errorHelp, explainError } from './error_help'
 
 /**
  * A function that evaluates a Page and returns whether it matches.
@@ -416,6 +417,15 @@ export async function waitForWindowByMatcher(
         }, interval)
       }),
     ])
+  } catch (err) {
+    // either our own poll timeout or Playwright's waitForEvent timeout, whichever
+    // lost the race first - both mean "nothing matched". Anything else (the app
+    // closing, a matcher that threw) is passed through untouched.
+    const errString = errToString(err)
+    if (/timeout/i.test(errString)) {
+      throw explainError(err, errorHelp.waitForWindow, errString)
+    }
+    throw err
   } finally {
     // Clean up the polling interval when the race completes
     if (pollIntervalId !== undefined) {

--- a/test/error_help.test.ts
+++ b/test/error_help.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict'
+import {
+  errorHelp,
+  explainError,
+  gcErrorMatch,
+  teardownErrorMatch,
+} from '../src/error_help'
+import { addTimeoutToPromise, retry } from '../src/utilities'
+
+describe('error help', () => {
+  describe('the retry-matcher invariant', () => {
+    // Help text is APPENDED to the error's own message, and retry() matches its
+    // errorMatch list case-insensitively against the whole message. A help
+    // string quoting one of those matchers would make an error that should
+    // throw immediately start being retried instead - re-firing whatever side
+    // effects the call already had. Nothing may quote one, ever.
+    const matchers = [...teardownErrorMatch, ...gcErrorMatch]
+
+    for (const [name, help] of Object.entries(errorHelp)) {
+      it(`errorHelp.${name} must not contain a retry matcher`, () => {
+        const lowered = help.toLowerCase()
+        for (const matcher of matchers) {
+          assert.ok(
+            !lowered.includes(matcher.toLowerCase()),
+            `errorHelp.${name} contains the retry matcher "${matcher}", which ` +
+              `would make errors carrying this help retryable`,
+          )
+        }
+      })
+    }
+
+    it('should cover every help string', () => {
+      assert.ok(Object.keys(errorHelp).length > 0)
+    })
+  })
+
+  describe('explainError', () => {
+    it('should append the help to the message and the stack', () => {
+      const err = new Error('something broke')
+      // whatever reported this first would have rendered .stack by now, and V8
+      // caches it - the explanation has to survive that
+      void err.stack
+
+      const explained = explainError(err, 'here is why') as Error
+
+      assert.strictEqual(explained, err)
+      assert.match(explained.message, /something broke\n\nhere is why/)
+      assert.match(explained.stack as string, /here is why/)
+    })
+
+    it('should not append the same help twice', () => {
+      const err = explainError(new Error('nope'), 'here is why') as Error
+      explainError(err, 'here is why')
+
+      assert.strictEqual(err.message.split('here is why').length, 2)
+    })
+
+    it('should return a real Error when given something else', () => {
+      const explained = explainError('just a string', 'here is why', 'rendered')
+
+      assert.ok(explained instanceof Error)
+      assert.strictEqual(explained.message, 'rendered\n\nhere is why')
+    })
+
+    it('should keep the original error when the message cannot be set', () => {
+      const err = Object.freeze(new Error('frozen solid'))
+
+      assert.strictEqual(explainError(err, 'here is why'), err)
+      assert.strictEqual(err.message, 'frozen solid')
+    })
+  })
+
+  describe('explained errors', () => {
+    it('should explain a retry() timeout', async () => {
+      const fn = async () => {
+        throw new Error('Always fails')
+      }
+
+      const err = await retry(fn, {
+        poll: 2,
+        timeout: 10,
+        errorMatch: 'Always fails',
+      }).catch((e: Error) => e)
+
+      assert.match(err.message, /Timeout after 10ms/)
+      assert.match(err.message, /The "Last throw"/)
+    })
+
+    it('should explain an addTimeoutToPromise() timeout', async () => {
+      await assert.rejects(addTimeoutToPromise(new Promise(() => null), 20), {
+        message: /timeout after 20ms\n\nThe promise did not settle in time\./,
+      })
+    })
+
+    it('should leave a caller-supplied timeout message alone', async () => {
+      await assert.rejects(
+        addTimeoutToPromise(new Promise(() => null), 20, 'my own message'),
+        { message: 'my own message' },
+      )
+    })
+  })
+})

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -15,8 +15,9 @@ describe('Utilities', () => {
     })
 
     it('should reject the promise after timeout', async () => {
+      // the message is followed by an explanation - see error_help.test.ts
       await assert.rejects(addTimeoutToPromise(new Promise(() => null), 100), {
-        message: 'timeout after 100ms',
+        message: /^timeout after 100ms$/m,
       })
     })
   })


### PR DESCRIPTION
You asked for more errors like the `retry()` garbage-collection one, with suggested fixes. **Stacked on #125 → #118 → #115.**

## Mechanism

New leaf module `src/error_help.ts` that **imports nothing**. That's forced: `find_parse_builds.ts` is pure Node, and `utilities.ts` does `import * as helpers from './'`, so a leaf is the only place both can import from without a require cycle.

- `explainError(err, help, errString)` — generalized from `explainGcError()`, carrying over all of its care: the non-Error branch, the already-explained guard (nested `retry()` calls see the same error twice), the frozen/getter-only-`message` try/catch, and the `.stack` rebuild that exists because V8 renders `.stack` lazily then caches it.
- `errorHelp` — one object holding every help string, so the invariant test can iterate them.
- `teardownErrorMatch` / `gcErrorMatch` moved here, next to the help they constrain.

`error_help.ts` is **not** re-exported from `index.ts` — the public API stays at exactly 43 exports. `utilities.ts` shrinks by ~129 lines.

## The invariant that makes this safe

Help text is **appended to the error's own message**, and `retry()` matches `errorMatch` case-insensitively against the *whole* message. So a help string quoting e.g. `"Execution context was destroyed"` would make a should-throw-immediately error start being **retried** — re-firing whatever side effects the call already had. That's the exact failure the GC help warns about.

`test/error_help.test.ts` asserts, per help string, that it contains no matcher from either list. Proven to bite — adding a deliberately-colliding string produces:

```
1) errorHelp.probe must not contain a retry matcher:
   AssertionError: errorHelp.probe contains the retry matcher
   "Execution context was destroyed", which would make errors carrying this help retryable
```

## What got help, and the fix each names

| Error | What it now tells you to do |
|---|---|
| `retry()::Timeout after Xms` | The repeated "Last throw" is the real problem — the timeout is just it repeating. Fix that condition or use the matching `waitFor*` helper; if merely slow, `{ timeout: 15000 }` or `setRetryOptions()` + `resetRetryOptions()`; to retry a new error, `errorMatch` — which **REPLACES** the default list. |
| `timeout after Xms` (`addTimeoutToPromise`) | It does **not** cancel the work, which keeps running and can fail later. Raise `timeoutMs`, pass `timeoutMessage` to identify the call, or await without the wrapper to see the real error. |
| `findLatestBuild()` finds nothing | Run `npm run package` first. The message now names the directory **actually** searched — it previously hard-coded "out" even when given a custom one. A missing directory now throws this instead of a bare `ENOENT`. |
| `Platform not found in directory name` | Lists the accepted tokens, notes forge/packager emit them by default, and offers passing the `.app`/`.exe` path directly (which skips name parsing entirely). |
| `No ipcMain handler registered for 'x'` | Channel names match exactly; `ipcMain.on()` where you meant `.handle()` is invisible to this function; lazy registration means the test got there first; use `ipcMainEmit()`/`ipcMainCallFirstListener()` for `on()` channels. Attached **Node-side**, since the throw happens inside an `evaluate()` callback. |
| `waitForWindowBy*` timeout | Dump `electronApp.windows()`, check `page.url()`/`title()` — a window mid-navigation reports both empty; string patterns are substring **and** case-sensitive. Applied in a `catch` gated on `/timeout/i`, so an app-closed error passes through untouched. |

## Deliberately rejected

- **`getWindowByTitle`/`getWindowByUrl` finding nothing** — they **return `undefined`**, they never throw. Nothing to explain; the pain shows up later as `undefined` used as a `Page`. Fixing that means changing the return contract — out of scope, but worth its own issue.
- **`parseElectronApp`'s other throws** — already name the directory, or already carry a paragraph and an issue link. `Platform not supported` is unreachable (the platform is already narrowed).
- **`No ipcRenderer/ipcMain listeners for 'x'`** — already say the channel and that nobody is listening.
- **`menu_helpers.ts`** — untouched, because #126 is editing that file. Its two candidates (`Menu item with id "X" not found` → suggest `waitForMenuItemById()`, ids are case-sensitive, dump via `getApplicationMenu()`; and `getMenuItemAttribute` → the property may have failed to serialize rather than being absent) are a follow-up. The `ipcMainInvokeHandler` pattern here is the template for doing it across the evaluate boundary.

## Verification

- **67 passing** (was 52), 0 failing; `tsc --noEmit`, `lint`, `prettier --check` all clean
- **65/65 e2e**
- Public API unchanged at 43 exports; `error_help.ts` is `@ignore`d so it leaks nothing into the README (which gained 5 lines: a `@throws` on `ipcMainInvokeHandler`)

One existing assertion changed: `test/utilities.test.ts` compared the `addTimeoutToPromise` message with strict equality; now `/^timeout after 100ms$/m`, pinning the same first line while allowing the appended help.

## Note

`explainGcError()` was dropped rather than kept as a thin wrapper — it had exactly one call site, now `explainError(err, errorHelp.gc, errString)`. It was internal and never exported, so nothing outside changes. Say the word if you'd rather keep the named function.

<!-- claude-session:515d819e-6f5b-44e2-a424-d9bcd97d1298 -->
🔖 **Claude agent:** electron-playwright-helpers-03  
session id: `515d819e-6f5b-44e2-a424-d9bcd97d1298`