### PR TITLE
feat: explain the menu helper errors, and how to find the right item

### DIFF
--- a/example-project/e2e-tests/e2e.spec.ts
+++ b/example-project/e2e-tests/e2e.spec.ts
@@ -346,6 +346,38 @@ test('find a menu item by role using `findMenuItem()`', async () => {
   expect(menuItem.label).toBe('Zoom In')
 })
 
+test('a missing menu item explains how to find the right id', async () => {
+  const electronApp = getApp()
+  // the throw happens inside the evaluate() callback, in the Electron process.
+  // What this checks is that the explanation survives the trip back out.
+  await expect(
+    clickMenuItemById(electronApp, 'no-such-menu-item')
+  ).rejects.toThrow(/getApplicationMenu\(electronApp\) returns the entire menu/)
+})
+
+test('a missing menu item attribute explains serializationErrors', async () => {
+  const electronApp = getApp()
+  await expect(
+    // A misspelled attribute is the realistic way to reach this branch. Most
+    // properties Electron leaves unset come back as null rather than undefined
+    // - `accelerator` on this same item does - so they resolve instead of
+    // throwing. TypeScript would normally catch the typo; the cast is what a
+    // plain-JS caller gets for free.
+    getMenuItemAttribute(
+      electronApp,
+      'checkbox',
+      'acclerator' as keyof Electron.MenuItem
+    )
+  ).rejects.toThrow(/serializationErrors/)
+})
+
+test('an unmatched property explains how matching actually works', async () => {
+  const electronApp = getApp()
+  await expect(
+    clickMenuItem(electronApp, 'label', 'No Such Label')
+  ).rejects.toThrow(/Matching is a strict === against a serialized copy/)
+})
+
 test('select the checkbox menuItem and watch its status change', async () => {
   const electronApp = getApp()
   const checkboxBefore = await getMenuItemById(electronApp, 'checkbox')

--- a/src/error_help.ts
+++ b/src/error_help.ts
@@ -217,6 +217,98 @@ export const errorHelp = {
     'ipcMainCallFirstListener() instead.',
   ].join('\n'),
 
+  /** appended when the app has no `Menu.setApplicationMenu()` menu installed */
+  noApplicationMenu: [
+    'Every menu helper here reads the APPLICATION menu, the one installed with',
+    'Menu.setApplicationMenu(). Menu.getApplicationMenu() returned null, so',
+    'either nothing has been installed yet or the menu under test is a different',
+    'kind of menu entirely.',
+    '',
+    'A context menu - built with Menu.buildFromTemplate() and shown with',
+    'menu.popup() - and a Tray menu are never reachable this way, no matter how',
+    'they are built. Those have to be driven through whatever code opens them.',
+    '',
+    'If the app does install an application menu, but installs it late (inside',
+    'app.whenReady(), or when the first window opens), the test just got there',
+    'first: wait for the item with waitForMenuItem(electronApp, "my-item")',
+    'instead of reading the menu immediately after launch.',
+    '',
+    'Also worth checking on Windows and Linux: an app that never calls',
+    'Menu.setApplicationMenu() has no application menu at all there, even though',
+    'the very same app shows a default menu on macOS.',
+  ].join('\n'),
+
+  /** appended when no menu item has the requested id */
+  menuItemNotFound: [
+    'Menu.getMenuItemById() searches the whole application menu, submenus',
+    'included, and compares ids exactly - the match is case-sensitive and a',
+    'stray space counts. So either the id is spelled differently than the',
+    'template spells it, or the item is not in the menu at this moment.',
+    '',
+    'Print what is really there rather than guessing:',
+    'getApplicationMenu(electronApp) returns the entire menu as plain data, ids',
+    'and all. Keep in mind that only items given an explicit `id` in the',
+    'template have one - an item declared purely by role does not, and has to be',
+    'matched some other way, e.g. clickMenuItem(electronApp, "role", "copy").',
+    '',
+    'If the menu is built or rebuilt while the test runs, wait for the item',
+    'rather than demanding it immediately: waitForMenuItem(electronApp,',
+    '"my-item") resolves once it shows up.',
+  ].join('\n'),
+
+  /** appended when a menu item exists but the requested attribute is undefined */
+  menuItemAttribute: [
+    'The menu item was found; the property on it came back undefined. Two quite',
+    'different things produce that.',
+    '',
+    'Usually the property is simply not set. Most MenuItem properties are',
+    'undefined unless the template supplied them, and several are meaningful',
+    'only for one type of item - `checked` on an item that is not a checkbox or',
+    'radio, `submenu` on a plain item.',
+    '',
+    'It can also mean the value was dropped on the way out of the main process,',
+    'because only serializable values survive that trip. Functions never arrive',
+    '- `click` above all - and anything that failed to convert is recorded under',
+    '`serializationErrors` on the object getMenuItemById(electronApp, id)',
+    'returns. Look there before concluding the property is absent, and read the',
+    'icon through that same object, where a NativeImage arrives as a data URL.',
+  ].join('\n'),
+
+  /** appended when no menu item matches a property/value pair */
+  menuItemByProperty: [
+    'No item in the application menu had that property set to that value.',
+    'Matching is a strict === against a serialized copy of the menu, so a number',
+    'does not match its string form, `true` does not match "true", and a RegExp',
+    'is compared as an object rather than applied as a pattern. (`role` is the',
+    'one exception: it is lower-cased before comparing.)',
+    '',
+    'Print the menu with getApplicationMenu(electronApp) and match against what',
+    'is actually in it. Properties that cannot cross out of the main process are',
+    'not there to match on at all: functions such as `click` are stripped, and an',
+    '`icon` arrives as a data URL rather than as a NativeImage.',
+    '',
+    'If the item has an id, prefer clickMenuItemById() or getMenuItemById() -',
+    'they ask Electron for the item directly instead of scanning a copy, so they',
+    'are both faster and harder to get wrong.',
+  ].join('\n'),
+
+  /** appended when a matched menu item carries no `commandId` to click through */
+  menuItemNoCommandId: [
+    'The item matched, but it carries no commandId. clickMenuItem() needs one:',
+    'it matches against a serialized copy of the menu out here, then uses the',
+    'commandId to find the real item again inside the main process.',
+    '',
+    'Check `serializationErrors` on the object findMenuItem(electronApp,',
+    'property, value) returns - if commandId is listed there, that is the',
+    'reason, and the item itself is fine.',
+    '',
+    'Otherwise the match probably landed somewhere unintended: a property and',
+    'value shared by several entries can match a separator or a submenu header',
+    'rather than the clickable item you meant. Narrow the match, or - if the',
+    'item has an id - use clickMenuItemById(), which skips this lookup and its',
+    'failure mode entirely.',
+  ].join('\n'),
+
   /** appended when `waitForWindowBy*()` times out */
   waitForWindow: [
     'No window already open matched, and no window that opened during the wait',

--- a/src/menu_helpers.ts
+++ b/src/menu_helpers.ts
@@ -1,6 +1,35 @@
 import type { ElectronApplication } from 'playwright-core'
+import { errorHelp, explainError } from './error_help'
 import { electronWaitForFunction } from './general_helpers'
-import { RetryOptions, retry } from './utilities'
+import { RetryOptions, errToString, retry } from './utilities'
+
+/**
+ * Attach an explanation to the errors these helpers throw from inside an
+ * `evaluate()` callback.
+ *
+ * The callback runs in the Electron process and cannot see anything in this
+ * module, so it can only throw a bare message. Matching that message back here
+ * is what lets the note be added. Every caller re-throws, so nothing is
+ * swallowed: an error this does not recognize comes back untouched.
+ *
+ * @ignore
+ */
+function explainMenuError(err: unknown): never {
+  const errString = errToString(err)
+  if (errString.includes('No application menu found')) {
+    throw explainError(err, errorHelp.noApplicationMenu, errString)
+  }
+  if (errString.includes('has no attribute')) {
+    throw explainError(err, errorHelp.menuItemAttribute, errString)
+  }
+  if (
+    errString.includes('Menu item with id') ||
+    errString.includes('Menu item with commandId')
+  ) {
+    throw explainError(err, errorHelp.menuItemNotFound, errString)
+  }
+  throw err
+}
 
 /**
  * Execute the `.click()` method on the element with the given id.
@@ -39,7 +68,7 @@ export function clickMenuItemById(
         }
       }, id),
     { disable: true, ...options },
-  )
+  ).catch(explainMenuError)
 }
 
 /**
@@ -67,12 +96,22 @@ export async function clickMenuItem<P extends keyof MenuItemPartial>(
   value: MenuItemPartial[P],
   options: Partial<RetryOptions> = {},
 ): Promise<unknown> {
+  // findMenuItem() reads the menu through getApplicationMenu(), which explains
+  // its own errors, so there is nothing to add around this call
   const menuItem = await findMenuItem(electronApp, property, value)
   if (!menuItem) {
-    throw new Error(`Menu item with ${property} = ${value} not found`)
+    throw explainError(
+      new Error(`Menu item with ${property} = ${value} not found`),
+      errorHelp.menuItemByProperty,
+    )
   }
   if (menuItem.commandId === undefined) {
-    throw new Error(`Menu item with ${property} = ${value} has no commandId`)
+    // an item Electron built without a commandId cannot be clicked through the
+    // menu at all - matching harder will not help, so this gets its own note
+    throw explainError(
+      new Error(`Menu item with ${property} = ${value} has no commandId`),
+      errorHelp.menuItemNoCommandId,
+    )
   }
   return await retry(
     () =>
@@ -151,7 +190,7 @@ export function getMenuItemAttribute<T extends keyof Electron.MenuItem>(
         { menuId, attr },
       ),
     options,
-  )
+  ).catch(explainMenuError)
   return resultPromise as Promise<Electron.MenuItem[T]>
 }
 
@@ -338,7 +377,7 @@ export function getMenuItemById(
         { menuId },
       ),
     options,
-  )
+  ).catch(explainMenuError)
 }
 
 /**
@@ -455,7 +494,7 @@ export function getApplicationMenu(
         return cleanItems
       }),
     options,
-  )
+  ).catch(explainMenuError)
 }
 
 /**
@@ -526,7 +565,7 @@ export async function waitForMenuItem(
       return !!menu.getMenuItemById(id as string)
     },
     id,
-  )
+  ).catch(explainMenuError)
 }
 
 /**
@@ -568,5 +607,5 @@ export async function waitForMenuItemStatus<P extends keyof Electron.MenuItem>(
       return menuItem[property] === value
     },
     { id, value, property },
-  )
+  ).catch(explainMenuError)
 }


### PR DESCRIPTION
Follow-up to #128, which added `errorHelp` but deliberately left the menu helpers alone because #126 was still editing that file. Both have landed, so this finishes the job.

### The problem

`Menu item with id "save-file" not found` names a symptom and stops. It does not say that ids are matched exactly and case-sensitively, that only items given an explicit `id` in the template have one at all, or that `getApplicationMenu(electronApp)` will print what is actually in the menu. Each of those is the next thing the reader needs.

### What's added

Five entries in `errorHelp`:

| entry | covers |
| --- | --- |
| `noApplicationMenu` | These helpers only read the menu installed with `Menu.setApplicationMenu()`. A context menu or Tray menu is never reachable this way; an app that installs its menu late needs waiting for; and Windows/Linux have no menu at all where macOS shows a default one. |
| `menuItemNotFound` | Exact, case-sensitive matching. Role-only items have no id. Dump the menu. Wait for it if it's built while the test runs. |
| `menuItemAttribute` | The property may be genuinely unset, **or** may have been dropped in serialization — which #126 now records under `serializationErrors`. |
| `menuItemByProperty` | Matching is `===` against a serialized copy: no type coercion, no RegExp, and functions aren't there to match on. |
| `menuItemNoCommandId` | Check `serializationErrors`, then suspect the match landed on a separator or submenu header. |

The throws happen inside `evaluate()` callbacks, which can't see this module, so there is nothing to attach at the throw site. `explainMenuError()` matches the message on the way back out instead — and **re-throws anything it doesn't recognize**, so no error is swallowed or reclassified.

### Verification

- **72 unit tests.** The existing "no help string may contain a retry matcher" invariant test picks up all five automatically, since it iterates `errorHelp`. That guard matters here: help text is appended to the message, and `retry()` substring-matches the whole message, so a help string quoting a matcher would silently turn a fail-fast error into a retried one.
- **68 e2e tests** (65 + 3 new). The e2e tests are the point rather than a formality — what's actually being checked is that the note survives the trip back out of the Electron process.

### One thing the tests turned up

Electron reports an unset `accelerator` as `null`, not `undefined`, so `getMenuItemAttribute()` **resolves with `null`** there rather than throwing. The `has no attribute` branch is reached by a misspelled attribute name, which is the realistic case anyway. That's recorded in a comment on the test rather than left for the next person to rediscover.

<!-- claude-session:515d819e-6f5b-44e2-a424-d9bcd97d1298 -->
🔖 **Claude agent:** electron-playwright-helpers-03  
session id: `515d819e-6f5b-44e2-a424-d9bcd97d1298`