### PR TITLE
refactor: keep the original error as `cause`, now that ES2022 allows it

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,12 @@ import tseslint from 'typescript-eslint'
 
 export default defineConfig([
   {
+    // `npm run lint` passes `src` explicitly, so this only matters to someone
+    // who runs `eslint .` by hand - which otherwise reports errors in compiled
+    // output they cannot fix in a source file.
+    ignores: ['dist/**', 'example-project/**'],
+  },
+  {
     // same scope the old `eslint src/**/*.ts` script had
     files: ['src/**/*.ts'],
     extends: [
@@ -31,11 +37,6 @@ export default defineConfig([
         'error',
         { caughtErrors: 'all', caughtErrorsIgnorePattern: '^_' },
       ],
-      // New in eslint:recommended as of ESLint 10. It fires once, at
-      // find_parse_builds.ts:383, which rethrows without `{ cause: err }`.
-      // The proper fix needs `lib: ES2022` for `ErrorOptions`, and tsconfig
-      // still targets ES2019 - so this stays off until the target moves.
-      'preserve-caught-error': 0,
     },
   },
 ])

--- a/src/find_parse_builds.ts
+++ b/src/find_parse_builds.ts
@@ -406,6 +406,9 @@ export function parseElectronApp(buildDir: string): ElectronAppInfo {
           `Could not read package.json in ${resourcesDir}: ${
             err instanceof Error ? err.message : String(err)
           }. If that file exists and is valid, we may not handle this Electron layout on Linux yet - please submit a bug report or pull request!`,
+          // the message already quotes err.message, but only the cause carries
+          // the original stack and, for an fs error, its `code` and `path`
+          { cause: err },
         )
       }
     }


### PR DESCRIPTION
`eslint.config.mjs` carried this note:

> New in `eslint:recommended` as of ESLint 10. It fires once, at `find_parse_builds.ts:383`, which rethrows without `{ cause: err }`. The proper fix needs `lib: ES2022` for `ErrorOptions`, and tsconfig still targets ES2019 — so this stays off until the target moves.

#123 moved the target. The note is stale, so the rule comes back on and the actual fix goes in.

### Why the cause is worth keeping

The rethrow in `parseElectronApp()` quotes `err.message`, but a message is all it kept. The cause carries the original stack and, for an `fs` error, the `code` and `path` — which is exactly the missing-vs-unreadable-vs-malformed distinction the comment above that throw exists to preserve.

### Verification

Mutation-tested rather than assumed: removing `{ cause: err }` again makes `npm run lint` report `preserve-caught-error` at that line. With it in place, both `npm run lint` and `tsc --noEmit` are clean, and 67 unit tests pass.

### Also: `eslint .` is now clean

`ignores: ['dist/**', 'example-project/**']` at the config level. `npm run lint` passes `src` explicitly so it was never affected, but a bare `eslint .` reported errors in compiled output that nobody can fix in a source file, and tried to lint `example-project/` — which has its own config — with this one.

<!-- claude-session:515d819e-6f5b-44e2-a424-d9bcd97d1298 -->
🔖 **Claude agent:** electron-playwright-helpers-03  
session id: `515d819e-6f5b-44e2-a424-d9bcd97d1298`